### PR TITLE
ArgoCD helm integration for netflix-frontend

### DIFF
--- a/k8s/dev/ArgoApps/netflix-frontend-helm.yaml
+++ b/k8s/dev/ArgoApps/netflix-frontend-helm.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: netflix-frontend-dev
-  namespace: dev
+  namespace: argocd
 spec:
   project: default
   source:

--- a/k8s/dev/ArgoApps/netflix-frontend-helm.yaml
+++ b/k8s/dev/ArgoApps/netflix-frontend-helm.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: netflix-frontend-dev
+  namespace: dev
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/barrotem/NetflixInfra
+    targetRevision: dev
+    path: k8s/helm/netflix-frontend
+    helm:
+      releaseName: netflix-frontend-dev
+      valueFiles:
+        - values.yaml
+        - values-dev.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: dev
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s/dev/ArgoApps/netflix-frontend.yaml
+++ b/k8s/dev/ArgoApps/netflix-frontend.yaml
@@ -3,7 +3,7 @@
 #kind: Application
 #metadata:
 #  name: netflix-frontend-dev
-#  namespace: dev
+#  namespace: argocd
 #  finalizers:
 #    # Delete application related resources when issuing application delete
 #    - resources-finalizer.argocd.argoproj.io

--- a/k8s/dev/ArgoApps/netflix-frontend.yaml
+++ b/k8s/dev/ArgoApps/netflix-frontend.yaml
@@ -1,23 +1,23 @@
-# argoCD configuration file responsible for the netflix-fe application deployment
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: netflix-fe
-  namespace: argocd
-  finalizers:
-    # Delete application related resources when issuing application delete
-    - resources-finalizer.argocd.argoproj.io
-spec:
-  project: default
-  source:
-    repoURL: https://github.com/barrotem/NetflixInfra
-    targetRevision: dev
-    path: k8s/dev/NetflixFrontend
-  destination:
-    server: https://kubernetes.default.svc
-    namespace: dev
-  syncPolicy:
-    automated:
-      prune: false
-      selfHeal: false
-      allowEmpty: false
+## argoCD configuration file responsible for the netflix-fe application deployment
+#apiVersion: argoproj.io/v1alpha1
+#kind: Application
+#metadata:
+#  name: netflix-frontend-dev
+#  namespace: dev
+#  finalizers:
+#    # Delete application related resources when issuing application delete
+#    - resources-finalizer.argocd.argoproj.io
+#spec:
+#  project: default
+#  source:
+#    repoURL: https://github.com/barrotem/NetflixInfra
+#    targetRevision: dev
+#    path: k8s/dev/NetflixFrontend
+#  destination:
+#    server: https://kubernetes.default.svc
+#    namespace: dev
+#  syncPolicy:
+#    automated:
+#      prune: false
+#      selfHeal: false
+#      allowEmpty: false

--- a/k8s/dev/ArgoApps/netflix-mc.yaml
+++ b/k8s/dev/ArgoApps/netflix-mc.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: netflix-mc
+  name: netflix-mc-dev
   namespace: argocd
   finalizers:
     # Delete application related resources when issuing application delete

--- a/k8s/dev/ArgoApps/netflix-nginx.yaml
+++ b/k8s/dev/ArgoApps/netflix-nginx.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: netflix-nginx
+  name: netflix-nginx-dev
   namespace: argocd
   finalizers:
    # Delete application related resources when issuing application delete

--- a/k8s/dev/Grafana/deployment.yaml
+++ b/k8s/dev/Grafana/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: grafana-deployment
+  name: grafana-dev-deployment
   labels:
     app: grafana
 spec:

--- a/k8s/dev/Grafana/service.yaml
+++ b/k8s/dev/Grafana/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: grafana-service
+  name: grafana-dev-service
   labels:
     app: grafana
 spec:

--- a/k8s/dev/NetflixFrontend/canary-deployment.yaml
+++ b/k8s/dev/NetflixFrontend/canary-deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: netflixfe-canary-deployment
+  name: netflix-frontend-dev-canary-deployment
   labels:
     app: netflixfe-canary
 spec:

--- a/k8s/dev/NetflixFrontend/canary-ingress.yaml
+++ b/k8s/dev/NetflixFrontend/canary-ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: netflix-frontend-ingress-https-canary
+  name: netflix-frontend-dev-ingress-https-canary
   annotations:
     nginx.ingress.kubernetes.io/canary: "true"
     nginx.ingress.kubernetes.io/canary-by-header: "Destination"
@@ -24,6 +24,6 @@ spec:
           backend:
             # This assumes http-svc exists and routes to healthy endpoints
             service:
-              name: netflixfe-canary-service
+              name: netflix-frontend-dev-canary-service
               port:
                 number: 3000

--- a/k8s/dev/NetflixFrontend/canary-service.yaml
+++ b/k8s/dev/NetflixFrontend/canary-service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: netflixfe-canary-service
+  name: netflix-frontend-dev-canary-service
   labels:
     app: netflixfe-canary
 spec:

--- a/k8s/dev/NetflixFrontend/deployment.yaml
+++ b/k8s/dev/NetflixFrontend/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: netflixfe-deployment
+  name: netflix-frontend-dev-deployment
   labels:
     app: netflixfe
 spec:

--- a/k8s/dev/NetflixFrontend/deployment.yaml
+++ b/k8s/dev/NetflixFrontend/deployment.yaml
@@ -21,7 +21,7 @@ spec:
           image: barrotem/netflix-app:v1.0.20
           env:
             - name: MOVIE_CATALOG_SERVICE
-              value: "http://netflix-mc-service:8080"
+              value: "http://netflix-mc-dev-service:8080"
             - name: AWS_SQS_QUEUE_URL
               value: "https://sqs.eu-north-1.amazonaws.com/352708296901/barrotem-netflix-events"
             - name: AWS_REGION

--- a/k8s/dev/NetflixFrontend/deployment.yaml
+++ b/k8s/dev/NetflixFrontend/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: netflix-frontend
-          image: barrotem/netflix-app:v1.0.20
+          image: barrotem/netflix-frontend-dev:v1.0.6
           env:
             - name: MOVIE_CATALOG_SERVICE
               value: "http://netflix-mc-dev-service:8080"

--- a/k8s/dev/NetflixFrontend/ingress.yaml
+++ b/k8s/dev/NetflixFrontend/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: netflix-frontend-ingress-https
+  name: netflix-frontend-dev-ingress-https
 spec:
   tls:
     - hosts:
@@ -19,6 +19,6 @@ spec:
           backend:
             # This assumes http-svc exists and routes to healthy endpoints
             service:
-              name: netflixfe-service
+              name: netflix-frontend-dev-service
               port:
                 number: 3000

--- a/k8s/dev/NetflixFrontend/service.yaml
+++ b/k8s/dev/NetflixFrontend/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: netflixfe-service
+  name: netflix-frontend-dev-service
   labels:
     app: netflixfe
 spec:

--- a/k8s/dev/NetflixMovieCatalog/deployment.yaml
+++ b/k8s/dev/NetflixMovieCatalog/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: netflix-mc-deployment
+  name: netflix-mc-dev-deployment
   labels:
     app: netflix-mc
 spec:

--- a/k8s/dev/NetflixMovieCatalog/service.yaml
+++ b/k8s/dev/NetflixMovieCatalog/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: netflix-mc-service
+  name: netflix-mc-dev-service
   labels:
     app: netflix-mc
 spec:

--- a/k8s/dev/NetflixNginx/configmap.yaml
+++ b/k8s/dev/NetflixNginx/configmap.yaml
@@ -9,6 +9,6 @@ data:
      listen 80;
      server_name  localhost;
      location / {
-       proxy_pass http://netflixfe-service:3000;
+       proxy_pass http://netflix-frontend-dev-service:3000;
       }
     }

--- a/k8s/dev/NetflixNginx/configmap.yaml
+++ b/k8s/dev/NetflixNginx/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-conf
+  name: nginx-dev-conf
 data:
   default.conf: |
     server {

--- a/k8s/dev/NetflixNginx/deployment.yaml
+++ b/k8s/dev/NetflixNginx/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: netflix-nginx-deployment
+  name: netflix-nginx-dev-deployment
   labels:
     app: netflix-nginx
 spec:
@@ -25,4 +25,4 @@ spec:
       volumes:
         - name: nginx-conf-files
           configMap:
-            name: nginx-conf
+            name: nginx-dev-conf

--- a/k8s/dev/NetflixNginx/service.yaml
+++ b/k8s/dev/NetflixNginx/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: netflix-nginx-service
+  name: netflix-nginx-dev-service
   labels:
     app: netflix-nginx
 spec:

--- a/k8s/helm/netflix-frontend/values-dev.yaml
+++ b/k8s/helm/netflix-frontend/values-dev.yaml
@@ -90,7 +90,7 @@ resources: {}
 
 env:
   - name: MOVIE_CATALOG_SERVICE
-    value: "http://netflix-mc-service:8080"
+    value: "http://netflix-mc-dev-service:8080"
   - name: AWS_SQS_QUEUE_URL
     #value: "https://sqs.eu-north-1.amazonaws.com/352708296901/barrotem-netflix-events"
     value: ""

--- a/k8s/prod/ArgoApps/netflix-frontend-helm.yaml
+++ b/k8s/prod/ArgoApps/netflix-frontend-helm.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: netflix-frontend-prod
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/barrotem/NetflixInfra
+    targetRevision: main
+    path: k8s/helm/netflix-frontend
+    helm:
+      releaseName: netflix-frontend-prod
+      valueFiles:
+        - values.yaml
+        - values-prod.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s/prod/ArgoApps/netflix-frontend.yaml
+++ b/k8s/prod/ArgoApps/netflix-frontend.yaml
@@ -1,23 +1,23 @@
-# argoCD configuration file responsible for the netflix-fe application deployment
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: netflix-fe
-  namespace: argocd
-  finalizers:
-    # Delete application related resources when issuing application delete
-    - resources-finalizer.argocd.argoproj.io
-spec:
-  project: default
-  source:
-    repoURL: https://github.com/barrotem/NetflixInfra
-    targetRevision: main
-    path: k8s/prod/NetflixFrontend
-  destination:
-    server: https://kubernetes.default.svc
-    namespace: prod
-  syncPolicy:
-    automated:
-      prune: false
-      selfHeal: false
-      allowEmpty: false
+## argoCD configuration file responsible for the netflix-fe application deployment
+#apiVersion: argoproj.io/v1alpha1
+#kind: Application
+#metadata:
+#  name: netflix-fe-prod
+#  namespace: argocd
+#  finalizers:
+#    # Delete application related resources when issuing application delete
+#    - resources-finalizer.argocd.argoproj.io
+#spec:
+#  project: default
+#  source:
+#    repoURL: https://github.com/barrotem/NetflixInfra
+#    targetRevision: main
+#    path: k8s/prod/NetflixFrontend
+#  destination:
+#    server: https://kubernetes.default.svc
+#    namespace: prod
+#  syncPolicy:
+#    automated:
+#      prune: false
+#      selfHeal: false
+#      allowEmpty: false

--- a/k8s/prod/ArgoApps/netflix-mc.yaml
+++ b/k8s/prod/ArgoApps/netflix-mc.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: netflix-mc
+  name: netflix-mc-prod
   namespace: argocd
   finalizers:
     # Delete application related resources when issuing application delete

--- a/k8s/prod/ArgoApps/netflix-nginx.yaml
+++ b/k8s/prod/ArgoApps/netflix-nginx.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: netflix-nginx
+  name: netflix-nginx-prod
   namespace: argocd
   finalizers:
    # Delete application related resources when issuing application delete

--- a/k8s/prod/Grafana/deployment.yaml
+++ b/k8s/prod/Grafana/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: grafana-deployment
+  name: grafana-dev-deployment
   labels:
     app: grafana
 spec:

--- a/k8s/prod/Grafana/service.yaml
+++ b/k8s/prod/Grafana/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: grafana-service
+  name: grafana-dev-service
   labels:
     app: grafana
 spec:

--- a/k8s/prod/NetflixFrontend/canary-deployment.yaml
+++ b/k8s/prod/NetflixFrontend/canary-deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: netflixfe-canary-deployment
+  name: netflix-frontend-prod-canary-deployment
   labels:
     app: netflixfe-canary
 spec:
@@ -21,4 +21,4 @@ spec:
           image: barrotem/netflixfe:github-wf-deploy-20
           env:
             - name: MOVIE_CATALOG_SERVICE
-              value: "http://netflix-mc-service:8080"
+              value: "http://netflix-mc-prod-service:8080"

--- a/k8s/prod/NetflixFrontend/canary-ingress.yaml
+++ b/k8s/prod/NetflixFrontend/canary-ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: netflix-frontend-ingress-https-canary
+  name: netflix-frontend-prod-ingress-https-canary
   annotations:
     nginx.ingress.kubernetes.io/canary: "true"
     nginx.ingress.kubernetes.io/canary-by-header: "Destination"

--- a/k8s/prod/NetflixFrontend/canary-service.yaml
+++ b/k8s/prod/NetflixFrontend/canary-service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: netflixfe-canary-service
+  name: netflix-frontend-prod-canary-service
   labels:
     app: netflixfe-canary
 spec:

--- a/k8s/prod/NetflixFrontend/deployment.yaml
+++ b/k8s/prod/NetflixFrontend/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: netflixfe-deployment
+  name: netflix-frontend-prod-deployment
   labels:
     app: netflixfe
 spec:
@@ -21,7 +21,7 @@ spec:
           image: barrotem/netflix-app:v1.0.21
           env:
             - name: MOVIE_CATALOG_SERVICE
-              value: "http://netflix-mc-service:8080"
+              value: "http://netflix-mc-prod-service:8080"
             - name: AWS_SQS_QUEUE_URL
               value: "https://sqs.eu-north-1.amazonaws.com/352708296901/barrotem-netflix-events"
             - name: AWS_REGION

--- a/k8s/prod/NetflixFrontend/inrgess.yaml
+++ b/k8s/prod/NetflixFrontend/inrgess.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: netflix-frontend-ingress-https
+  name: netflix-frontend-prod-ingress-https
 spec:
   tls:
     - hosts:
@@ -19,6 +19,6 @@ spec:
           backend:
             # This assumes http-svc exists and routes to healthy endpoints
             service:
-              name: netflixfe-service
+              name: netflix-frontend-prod-service
               port:
                 number: 3000

--- a/k8s/prod/NetflixFrontend/service.yaml
+++ b/k8s/prod/NetflixFrontend/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: netflixfe-service
+  name: netflix-frontend-prod-service
   labels:
     app: netflixfe
 spec:

--- a/k8s/prod/NetflixMovieCatalog/deployment.yaml
+++ b/k8s/prod/NetflixMovieCatalog/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: netflix-mc-deployment
+  name: netflix-mc-prod-deployment
   labels:
     app: netflix-mc
 spec:

--- a/k8s/prod/NetflixMovieCatalog/service.yaml
+++ b/k8s/prod/NetflixMovieCatalog/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: netflix-mc-service
+  name: netflix-mc-prod-service
   labels:
     app: netflix-mc
 spec:

--- a/k8s/prod/NetflixNginx/configmap.yaml
+++ b/k8s/prod/NetflixNginx/configmap.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-conf
+  name: nginx-prod-conf
 data:
   default.conf: |
     server {
      listen 80;
      server_name  localhost;
      location / {
-       proxy_pass http://netflixfe-service:3000;
+       proxy_pass http://netflix-frontend-prod-service:3000;
       }
     }

--- a/k8s/prod/NetflixNginx/deployment.yaml
+++ b/k8s/prod/NetflixNginx/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: netflix-nginx-deployment
+  name: netflix-nginx-prod-deployment
   labels:
     app: netflix-nginx
 spec:
@@ -25,4 +25,4 @@ spec:
       volumes:
         - name: nginx-conf-files
           configMap:
-            name: nginx-conf
+            name: nginx-prod-conf

--- a/k8s/prod/NetflixNginx/service.yaml
+++ b/k8s/prod/NetflixNginx/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: netflix-nginx-service
+  name: netflix-nginx-prod-service
   labels:
     app: netflix-nginx
 spec:


### PR DESCRIPTION
While changing most manifests on the repo,
I have allowed Helm and ArgoCD integration in order to deploy the netflix-frontend microservice 
dynamically, based on environment